### PR TITLE
Update alert threshold to reduce false positives

### DIFF
--- a/src/Pi4/gatus/config.yaml
+++ b/src/Pi4/gatus/config.yaml
@@ -11,7 +11,7 @@ endpoints:
       - "[CONNECTED] == true"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "Mail Server Lippok HTTPS"
@@ -25,7 +25,7 @@ endpoints:
       - "[CERTIFICATE_EXPIRATION] > 24h"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "Mail Server Lippok IMAP"
@@ -37,7 +37,7 @@ endpoints:
       - "[RESPONSETIME] < 2000"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "Mail Server Lippok SMTP"
@@ -49,7 +49,7 @@ endpoints:
       - "[RESPONSETIME] < 2000"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "Apollo NAS"
@@ -63,7 +63,7 @@ endpoints:
       - "[CERTIFICATE_EXPIRATION] > 24h"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "Apollo NAS Ping"
@@ -74,7 +74,7 @@ endpoints:
       - "[CONNECTED] == true"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "Olympus Page"
@@ -88,7 +88,7 @@ endpoints:
       - "[CERTIFICATE_EXPIRATION] > 24h"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "Portainer"
@@ -102,7 +102,7 @@ endpoints:
       - "[CERTIFICATE_EXPIRATION] > 24h"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "FritzBox"
@@ -113,7 +113,7 @@ endpoints:
       - "[CONNECTED] == true"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "FritzBox HTTPS"
@@ -127,7 +127,7 @@ endpoints:
       - "[CERTIFICATE_EXPIRATION] > 24h"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "pi3 Athena"
@@ -138,7 +138,7 @@ endpoints:
       - "[CONNECTED] == true"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "NAS Zeus"
@@ -152,7 +152,7 @@ endpoints:
       - "[CERTIFICATE_EXPIRATION] > 24h"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "NAS Zeus Ping"
@@ -163,7 +163,7 @@ endpoints:
       - "[CONNECTED] == true"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "Router Vieta"
@@ -174,7 +174,7 @@ endpoints:
       - "[CONNECTED] == true"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
   - name: "Router Minerva"
@@ -185,7 +185,7 @@ endpoints:
       - "[CONNECTED] == true"
     alerts:
       - type: discord
-        failure-threshold: 1
+        failure-threshold: 3
         success-threshold: 2
 
 alerting:


### PR DESCRIPTION
Update `failure-threshold` to 3 for all alerts in `src/Pi4/gatus/config.yaml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FinnPL/NoStar/pull/17?shareId=411d550d-f825-4f11-b2c4-b5b18c2ebafd).