### PR TITLE
Update docker-compose.yml

### DIFF
--- a/src/Pi4/docker-compose.yml
+++ b/src/Pi4/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - "HOMEPAGE_VAR_UNIFI_PASSWORD=${HOMEPAGE_VAR_UNIFI_PASSWORD}"
       - "HOMEPAGE_VAR_MAILCOW_API_KEY=${HOMEPAGE_VAR_MAILCOW_API_KEY}"
       - "HOMEPAGE_VAR_PORTAINER_API_KEY=${HOMEPAGE_VAR_PORTAINER_API_KEY}"
+      - "HOMEPAGE_ALLOWED_HOSTS=olympus.lippok.dev"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./homepage:/app/config


### PR DESCRIPTION
This pull request makes a small change to the `docker-compose.yml` file by adding an environment variable to configure allowed hosts for the `homepage` service.

* [`src/Pi4/docker-compose.yml`](diffhunk://#diff-e4f6e3e648ff76dc00593d63770e1272502791a3707ef8665a9947e01b783715R64): Added the `HOMEPAGE_ALLOWED_HOSTS` environment variable with the value `olympus.lippok.dev` to the `homepage` service configuration.